### PR TITLE
Make Cypher queries more specific

### DIFF
--- a/snb-interactive-neo4j/src/main/java/net/ellitron/ldbcsnbimpls/interactive/neo4j/Neo4jDb.java
+++ b/snb-interactive-neo4j/src/main/java/net/ellitron/ldbcsnbimpls/interactive/neo4j/Neo4jDb.java
@@ -376,8 +376,8 @@ public class Neo4jDb extends Db {
       Driver driver = ((Neo4jDbConnectionState) dbConnectionState).getDriver();
 
       String statement =
-          "   MATCH (:Person {id:{1}})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(message)"
-          + " WHERE message.creationDate <= {2} AND (message:Post OR message:Comment)"
+          "   MATCH (:Person {id:{1}})-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(message:Message)"
+          + " WHERE message.creationDate <= {2}"
           + " RETURN"
           + "   friend.id AS personId,"
           + "   friend.firstName AS personFirstName,"


### PR DESCRIPTION
I reviewed the Interactive Cypher implementations and ended up changing complex Q2 by moving node labels "`:Comment` or `:Post`" from the `WHERE` clause to the `MATCH` clause as a single `:Message` label. This might allow the query engine to generate better quality plans.

I introduced similar, but less significant changes in the implementations repository with https://github.com/ldbc/ldbc_snb_implementations/commit/6987a8f2fbcbc1e1cd60ff62260fb0fda7bee025. These can also be ported to this PR.